### PR TITLE
fix: findings of Codacy for the kubectl Dockerfile

### DIFF
--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -5,7 +5,7 @@ FROM bitnami/kubectl:${KUBECTL_VERSION}
 USER root
 
 RUN apt-get update \
-    && apt-get install -y gettext-base \
+    && apt-get --no-install-recommends install -y gettext-base=0.21-4 \
     && rm -rf /var/lib/apt/lists/*
 
 USER 1001


### PR DESCRIPTION
This PR fixes some findings of Codacy in the Dockerfile for the `kubectl` image.